### PR TITLE
Remove Drupal core patch #2855026-46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Draft template 1.x.x
+
+- Removed "Installation profiles do not support project:module format for dependencies" patch because it has already been merged into the Drupal core
+
 ## Draft template 1.9.0, 2018-09-20
 
 - Updated .gitignore to include router file for PHP's built-in webserver, which was added in Drupal 8.5 (`./docroot/.ht.router.php`)

--- a/composer.json
+++ b/composer.json
@@ -81,11 +81,7 @@
                 "docroot/themes/custom/*/composer.json"
             ]
         },
-        "patches": {
-            "drupal/core": {
-                "Installation profiles do not support project:module format for dependencies": "https://www.drupal.org/files/issues/2018-09-10/drupal-support_project_module_format_dependencies-2855026-49.patch"
-            }
-        },
+        "patches": {},
         "enable-patching": true
     }
 }


### PR DESCRIPTION
Patch title:
  Installation profiles do not support project:module
  format for dependencies

Closes #35 