### PR TITLE
Improve patches handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ install:
   # Add Composer's local bin directory to the PATH.
   - export PATH="$HOME/.composer/vendor/bin:$TRAVIS_BUILD_DIR/bin:$PATH"
 
-  # composer install should fail on bad patches.
-  - export COMPOSER_EXIT_ON_PATCH_FAILURE=1
-
   # Create the MySQL database and add a user for testing.
   - mysql -u root -e "CREATE DATABASE drupal; CREATE USER 'draft'@'localhost' IDENTIFIED BY 'draft'; GRANT ALL ON drupal.* TO 'draft'@'localhost';"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Draft template 1.x.x
 
+- Improved patches handling:
+    * Ensure that Drupal core patches apply correctly (i.e. well-known issue with `core/a`, `core/b` or `core/core` folders when patch adds (only) new files)
+    * Ensure that Composer aborts if a patch doesn't apply, avoiding problems with partially applied patches
 - Removed "Installation profiles do not support project:module format for dependencies" patch because it has already been merged into the Drupal core
 
 ## Draft template 1.9.0, 2018-09-20

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,11 @@
                 "docroot/themes/custom/*/composer.json"
             ]
         },
-        "patches": {},
-        "enable-patching": true
+        "enable-patching": true,
+        "composer-exit-on-patch-failure": true,
+        "patchLevel": {
+            "drupal/core": "-p2"
+        },
+        "patches": {}
     }
 }


### PR DESCRIPTION
  * Ensure that Drupal core patches apply correctly (i.e. well-known issue with `core/a`, `core/b` or `core/core` folders when patch adds (only) new files)
  * Ensure that Composer aborts if a patch doesn't apply, avoiding problems with partially applied patches

Closes #37 