### PR TITLE
Address PHP Fatal error: Call to undefined method Symfony\Component\Yaml\Dumper::setIndentation() (#72)

### DIFF
--- a/src/DrupalProject.php
+++ b/src/DrupalProject.php
@@ -95,8 +95,7 @@ HERE;
           'cache' => FALSE,
         ];
 
-        $yaml = new Dumper();
-        $yaml->setIndentation(2);
+        $yaml = new Dumper(2);
         $fs->dumpFile($development_services_file, $yaml->dump($config, PHP_INT_MAX));
       }
 


### PR DESCRIPTION
Closes #72 